### PR TITLE
Include linux arm64 builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,11 @@ jobs:
         working-directory: npm/cli-linux-x64
         env: { NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}" }
 
+      - name: Publish @yaakapp/cli-linux-arm64
+        run: npm publish --provenance --access public
+        working-directory: npm/cli-linux-arm64
+        env: { NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}" }
+
       - name: Publish @yaakapp/cli-win32-x64
         run: npm publish --provenance --access public
         working-directory: npm/cli-win32-x64

--- a/npm/cli-linux-arm64/package.json
+++ b/npm/cli-linux-arm64/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@yaakapp/cli-linux-arm64",
+  "version": "0.0.38",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/yaakapp/cli.git"
+  },
+  "os": [
+    "darwin"
+  ]
+}

--- a/npm/cli/common.js
+++ b/npm/cli/common.js
@@ -3,6 +3,7 @@ const BINARY_DISTRIBUTION_PACKAGES = {
   darwin_arm64: "@yaakapp/cli-darwin-arm64",
   darwin_x64: "@yaakapp/cli-darwin-x64",
   linux_x64: "@yaakapp/cli-linux-x64",
+  linux_arm64: "@yaakapp/cli-linux-arm64",
   win32_x64: "@yaakapp/cli-win32-x64",
 };
 

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -16,6 +16,7 @@
     "@yaakapp/cli-darwin-x64": "0.0.38",
     "@yaakapp/cli-darwin-arm64": "0.0.38",
     "@yaakapp/cli-linux-x64": "0.0.38",
+    "@yaakapp/cli-linux-arm64": "0.0.38",
     "@yaakapp/cli-win32-x64": "0.0.38"
   }
 }

--- a/npm/prepare-publish.js
+++ b/npm/prepare-publish.js
@@ -5,6 +5,7 @@ console.log("Copying binary files to packages")
 copyFileSync(join(__dirname, '../dist/cli_darwin_arm64/yaakcli'), join(__dirname, 'cli-darwin-arm64/bin/yaakcli'));
 copyFileSync(join(__dirname, '../dist/cli_darwin_amd64_v1/yaakcli'), join(__dirname, 'cli-darwin-x64/bin/yaakcli'));
 copyFileSync(join(__dirname, '../dist/cli_linux_amd64_v1/yaakcli'), join(__dirname, 'cli-linux-x64/bin/yaakcli'));
+copyFileSync(join(__dirname, '../dist/cli_linux_arm64_v8.0/yaakcli'), join(__dirname, 'cli-linux-arm64/bin/yaakcli'));
 copyFileSync(join(__dirname, '../dist/cli_windows_amd64_v1/yaakcli.exe'), join(__dirname, 'cli-win32-x64/bin/yaakcli.exe'));
 
 const version = process.env.YAAK_CLI_VERSION?.replace('v', '');
@@ -18,6 +19,7 @@ replacePackageVersion(join(__dirname, 'cli'), version);
 replacePackageVersion(join(__dirname, 'cli-darwin-arm64'), version);
 replacePackageVersion(join(__dirname, 'cli-darwin-x64'), version);
 replacePackageVersion(join(__dirname, 'cli-linux-x64'), version);
+replacePackageVersion(join(__dirname, 'cli-linux-arm64'), version);
 replacePackageVersion(join(__dirname, 'cli-win32-x64'), version);
 
 console.log("Done preparing for publish");
@@ -31,6 +33,7 @@ function replacePackageVersion(dir, version) {
       "@yaakapp/cli-darwin-x64": version,
       "@yaakapp/cli-darwin-arm64": version,
       "@yaakapp/cli-linux-x64": version,
+      "@yaakapp/cli-linux-arm64": version,
       "@yaakapp/cli-win32-x64": version,
     }
   }


### PR DESCRIPTION
Heyo 👋

I am trying to contribute to yaak by adding support for arm64 Linux build as I need it on my machine. I've noticed that there has been [a feedback post on including linux arm builds](https://feedback.yaak.app/p/linux-arm64) that is tagged as `Planned`. Luckily, building on arm is now easier as [arm64 hosted runners is now available for free](https://github.com/orgs/community/discussions/148648). 

I am sadly unable to further continue my builds (both on GH actions and locally) due to a missing arm variant of the CLI. With that said, **this PR includes the arm variant of the CLI when publishing to npm.**

P.S., You can see my current attempt in my [fork of the project](https://github.com/angeloanan/yaak/tree/arm-build).