### PR TITLE
Add distribution package path for aarch64 Linux

### DIFF
--- a/npm/cli/common.js
+++ b/npm/cli/common.js
@@ -2,6 +2,7 @@
 const BINARY_DISTRIBUTION_PACKAGES = {
   darwin_arm64: "@yaakapp/cli-darwin-arm64",
   darwin_x64: "@yaakapp/cli-darwin-x64",
+  linux_arm64: "@yaakapp/cli-linux-arm64",
   linux_x64: "@yaakapp/cli-linux-x64",
   win32_x64: "@yaakapp/cli-win32-x64",
 };


### PR DESCRIPTION
Fixes and issue introduced in #5, where the binary for `linux_arm64` platform cannot be located correctly due to a missing entry in `BINARY_DISTRIBUTION_PACKAGES`.