### PR TITLE
Fix `generate` prompt not very clear

### DIFF
--- a/cmd_generate.go
+++ b/cmd_generate.go
@@ -1,22 +1,21 @@
 package yaakcli
 
 import (
-	"github.com/pterm/pterm"
-	"github.com/spf13/cobra"
 	"os"
 	"os/exec"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
 )
 
 var generateCmd = &cobra.Command{
 	Use:   "generate",
 	Short: `Generate a "Hello World" Yaak plugin`,
 	Run: func(cmd *cobra.Command, args []string) {
-		defaultName := RandomName()
-		defaultPath := "./" + defaultName
+		pluginName, err := pterm.DefaultInteractiveTextInput.WithDefaultText("Plugin name").WithDefaultValue(RandomName()).Show()
+		CheckError(err)
 
-		_ = defaultPath
-
-		pluginDir, err := pterm.DefaultInteractiveTextInput.WithDefaultValue(defaultPath).Show()
+		pluginDir, err := pterm.DefaultInteractiveTextInput.WithDefaultText("Plugin dir").WithDefaultValue("./" + pluginName).Show()
 		CheckError(err)
 
 		if fileExists(pluginDir) {
@@ -29,10 +28,10 @@ var generateCmd = &cobra.Command{
 		CheckError(os.MkdirAll(pluginDir, 0755))
 
 		// Copy static files
-		copyFile("package.json", pluginDir, defaultName)
-		copyFile("tsconfig.json", pluginDir, defaultName)
-		copyFile("src/index.ts", pluginDir, defaultName)
-		copyFile("src/index.test.ts", pluginDir, defaultName)
+		copyFile("package.json", pluginDir, pluginName)
+		copyFile("tsconfig.json", pluginDir, pluginName)
+		copyFile("src/index.ts", pluginDir, pluginName)
+		copyFile("src/index.test.ts", pluginDir, pluginName)
 
 		primary := pterm.NewStyle(pterm.FgLightWhite, pterm.BgMagenta, pterm.Bold)
 


### PR DESCRIPTION
When running `generate` it wasn't very clear what `Input text:` meant. I assumed plugin name, but it only sets the directory, the templates don't get the prompted text.

This is just a small change to make it more explicit what the prompt is for.

Before:

```
$ npx @yaakapp/cli generate
Input text: my-plugin
Generating plugin to: my-plugin
...
$ grep -r name my-plugin/package.json
  "name": "yielding-yoke",
```

After:

```
$ go run . generate
Plugin name: my-plugin
Plugin dir: ./my-plugin-beta
Generating plugin to: ./my-plugin-beta
...
$ grep -r name my-plugin-beta/package.json
  "name": "my-plugin",
```